### PR TITLE
Add weather service with http integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A new Flutter project.
 
 This project is a starting point for a Flutter application.
 
+## Configuração
+
+Para acessar a API do OpenWeatherMap defina a variável de ambiente
+`OPENWEATHER_API_KEY` com sua chave de API antes de executar o aplicativo.
+
 A few resources to get you started if this is your first Flutter project:
 
 - [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)

--- a/lib/screens/weather_screen.dart
+++ b/lib/screens/weather_screen.dart
@@ -1,64 +1,116 @@
 import 'package:flutter/material.dart';
+
+import '../services/weather_service.dart';
 import 'tip_screen.dart';
 
-class WeatherScreen extends StatelessWidget {
+class WeatherScreen extends StatefulWidget {
   final String userName;
   const WeatherScreen({super.key, required this.userName});
 
   @override
+  State<WeatherScreen> createState() => _WeatherScreenState();
+}
+
+class _WeatherScreenState extends State<WeatherScreen> {
+  final WeatherService _service = WeatherService();
+  Map<String, dynamic>? _weatherData;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadWeather();
+  }
+
+  Future<void> _loadWeather() async {
+    try {
+      final data = await _service.fetchWeather(-5.77926, -35.20092);
+      setState(() {
+        _weatherData = data;
+      });
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final forecast = ["Ter - ☀️ 31°C", "Qua - 🌧 28°C", "Qui - ⛅ 30°C"];
+    final forecast = ['Ter - ☀️ 31°C', 'Qua - 🌧 28°C', 'Qui - ⛅ 30°C'];
+
+    Widget content;
+    if (_error != null) {
+      content = Center(child: Text('Erro: $_error'));
+    } else if (_weatherData == null) {
+      content = const Center(child: CircularProgressIndicator());
+    } else {
+      final main = _weatherData?['main'] ?? {};
+      final wind = _weatherData?['wind'] ?? {};
+      content = ListView(
+        children: [
+          if (widget.userName.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12.0),
+              child: Text(
+                'Bem-vindo, ${widget.userName}!',
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.deepPurple,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          const Text(
+            'Tempo agora em Natal - RN',
+            style: TextStyle(fontSize: 22, color: Color(0xFF003366)),
+            key: Key('tituloClimaAtual'),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            _weatherData?['dt'] != null
+                ? DateTime.fromMillisecondsSinceEpoch(_weatherData?['dt'] * 1000)
+                    .toLocal()
+                    .toString()
+                : '',
+          ),
+          const SizedBox(height: 32),
+Text('🌡️ Temperatura: ${main['temp']}°C',
+              style: const TextStyle(fontSize: 18)),
+          Text('🤒 Sensação térmica: ${main['feels_like']}°C',
+              style: const TextStyle(fontSize: 18)),
+          Text('💧 Umidade: ${main['humidity']}%',
+              style: const TextStyle(fontSize: 18)),
+          Text('💨 Vento: ${wind['speed']} m/s',
+              style: const TextStyle(fontSize: 18)),
+          const SizedBox(height: 32),
+          const Divider(),
+          const SizedBox(height: 16),
+          const Text('Próximos dias',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          ...forecast.map((item) => ListTile(title: Text(item))),
+          const SizedBox(height: 32),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const TipScreen()),
+              );
+            },
+            child: const Text('Dicas de Saúde'),
+          ),
+        ],
+      );
+    }
 
     return Scaffold(
       backgroundColor: const Color(0xFFEAF6FF),
       body: Padding(
         padding: const EdgeInsets.all(24),
-        child: ListView(
-          children: [
-            // Saudação com o nome do usuário
-            if (userName.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 12.0),
-                child: Text(
-                  'Bem-vindo, $userName!',
-                  style: TextStyle(
-                    fontSize: 22,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.deepPurple,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            const Text("Tempo agora em Natal - RN",
-                style: TextStyle(
-                    fontSize: 22, color: Color(0xFF003366)),
-                key: Key('tituloClimaAtual')),
-            const SizedBox(height: 8),
-            const Text("Segunda-feira, 06 de Maio"),
-            const Text("Atualizado às 17:30", style: TextStyle(color: Colors.grey)),
-            const SizedBox(height: 32),
-            const Text("🌡️ Temperatura: 29°C", style: TextStyle(fontSize: 18)),
-            const Text("🤒 Sensação térmica: 31°C", style: TextStyle(fontSize: 18)),
-            const Text("💧 Umidade: 76%", style: TextStyle(fontSize: 18)),
-            const Text("💨 Vento: 19 km/h", style: TextStyle(fontSize: 18)),
-            const SizedBox(height: 32),
-            const Divider(),
-            const SizedBox(height: 16),
-            const Text("Próximos dias", style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-            ...forecast.map((item) => ListTile(title: Text(item))),
-            const SizedBox(height: 32),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => const TipScreen()),
-                );
-              },
-              child: const Text('Dicas de Saúde'),
-            ),
-          ],
-        ),
+        child: content,
       ),
     );
   }
 }
+

--- a/lib/services/weather_service.dart
+++ b/lib/services/weather_service.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+class WeatherService {
+  static const _baseUrl = 'https://api.openweathermap.org/data/2.5/weather';
+
+  Future<Map<String, dynamic>> fetchWeather(double lat, double lon) async {
+    final apiKey = Platform.environment['OPENWEATHER_API_KEY'];
+    if (apiKey == null || apiKey.isEmpty) {
+      throw Exception('OPENWEATHER_API_KEY not found in environment');
+    }
+
+    final url = Uri.parse('$_baseUrl?lat=$lat&lon=$lon&appid=$apiKey&units=metric&lang=pt_br');
+    final response = await http.get(url);
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to fetch weather: ${response.statusCode}');
+    }
+
+    return json.decode(response.body) as Map<String, dynamic>;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.1.0
+  http: ^1.2.0
 
 
   # The following adds the Cupertino Icons font to your application.

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_weather_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Shows welcome message', (WidgetTester tester) async {
+    await tester.pumpWidget(const WeatherApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Bem-vindo ao Weather Tips!'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- include `http` package
- add a `WeatherService` to fetch data from OpenWeatherMap using an env var
- convert `WeatherScreen` to stateful and load forecast on init
- document API key usage
- fix widget test to run `WeatherApp`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a5777be98832592b3ee59bbe673b9